### PR TITLE
fix/travis-deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
   - yarn flow
 deploy:
   provider: script
+  skip_cleanup: true
   script:
     - yarn deploy
   on:

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "prepush": "yarn lint"
   },
   "now": {
+    "name": "build",
     "alias": "akronb-yard"
   }
 }


### PR DESCRIPTION
Исправил [ошибку](https://travis-ci.org/akronb/yard-frontend/builds/250137524) при деплое в мастер. Тестировал на [другой ветке](https://github.com/akronb/yard-frontend/tree/test/travis).

Необходимо выставить skip_cleanup: true в конфиге travis ci и проставить name для деплоя в now.